### PR TITLE
게시판 API 만들기 - Data REST 적용 및 테스트 정의

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-data-rest'
+	implementation 'org.springframework.data:spring-data-rest-hal-explorer'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/projectboard/ProjectBoardApplication.java
+++ b/src/main/java/com/projectboard/ProjectBoardApplication.java
@@ -1,4 +1,4 @@
-package com.projectboard.projectboard;
+package com.projectboard;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/src/main/java/com/projectboard/config/JpaConfig.java
+++ b/src/main/java/com/projectboard/config/JpaConfig.java
@@ -1,4 +1,4 @@
-package com.projectboard.projectboard.config;
+package com.projectboard.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/com/projectboard/domain/Article.java
+++ b/src/main/java/com/projectboard/domain/Article.java
@@ -1,4 +1,4 @@
-package com.projectboard.projectboard.domain;
+package com.projectboard.domain;
 
 import jakarta.persistence.*;
 import lombok.*;

--- a/src/main/java/com/projectboard/domain/ArticleComment.java
+++ b/src/main/java/com/projectboard/domain/ArticleComment.java
@@ -1,4 +1,4 @@
-package com.projectboard.projectboard.domain;
+package com.projectboard.domain;
 
 import jakarta.persistence.*;
 import lombok.*;

--- a/src/main/java/com/projectboard/domain/AuditingField.java
+++ b/src/main/java/com/projectboard/domain/AuditingField.java
@@ -1,4 +1,4 @@
-package com.projectboard.projectboard.domain;
+package com.projectboard.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;

--- a/src/main/java/com/projectboard/projectboard/repository/ArticleCommentRepository.java
+++ b/src/main/java/com/projectboard/projectboard/repository/ArticleCommentRepository.java
@@ -1,7 +1,0 @@
-package com.projectboard.projectboard.repository;
-
-import com.projectboard.projectboard.domain.ArticleComment;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface ArticleCommentRepository extends JpaRepository<ArticleComment, Long> {
-}

--- a/src/main/java/com/projectboard/projectboard/repository/ArticleRepository.java
+++ b/src/main/java/com/projectboard/projectboard/repository/ArticleRepository.java
@@ -1,7 +1,0 @@
-package com.projectboard.projectboard.repository;
-
-import com.projectboard.projectboard.domain.Article;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface ArticleRepository extends JpaRepository<Article, Long> {
-}

--- a/src/main/java/com/projectboard/repository/ArticleCommentRepository.java
+++ b/src/main/java/com/projectboard/repository/ArticleCommentRepository.java
@@ -1,0 +1,9 @@
+package com.projectboard.repository;
+
+import com.projectboard.domain.ArticleComment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+
+@RepositoryRestResource
+public interface ArticleCommentRepository extends JpaRepository<ArticleComment, Long> {
+}

--- a/src/main/java/com/projectboard/repository/ArticleRepository.java
+++ b/src/main/java/com/projectboard/repository/ArticleRepository.java
@@ -1,0 +1,9 @@
+package com.projectboard.repository;
+
+import com.projectboard.domain.Article;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+
+@RepositoryRestResource
+public interface ArticleRepository extends JpaRepository<Article, Long> {
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -23,9 +23,9 @@ spring:
       hibernate.default_batch_fetch_size: 100
 #  h2.console.enabled: true
   sql.init.mode: always # test data init
-#  data.rest:
-#    base-path: /api
-#    detection-strategy: annotated
+  data.rest:
+    base-path: /api
+    detection-strategy: annotated
 
 ---
 

--- a/src/test/java/com/projectboard/ProjectBoardApplicationTests.java
+++ b/src/test/java/com/projectboard/ProjectBoardApplicationTests.java
@@ -1,4 +1,4 @@
-package com.projectboard.projectboard;
+package com.projectboard;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;

--- a/src/test/java/com/projectboard/controller/DataRestTest.java
+++ b/src/test/java/com/projectboard/controller/DataRestTest.java
@@ -1,0 +1,69 @@
+package com.projectboard.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("Data rest - API 테스트")
+@Transactional
+@AutoConfigureMockMvc
+@SpringBootTest
+public class DataRestTest {
+    
+    @Autowired
+    private MockMvc mvc;
+
+    @DisplayName("[api] 게시글 리스트 조회")
+    @Test
+    public void articleList() throws Exception {
+        // then
+        mvc.perform(get("/api/articles"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+
+    @DisplayName("[api] 게시글 단건 조회")
+    @Test
+    public void article() throws Exception {
+        // then
+        mvc.perform(get("/api/articles/1"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+
+    @DisplayName("[api] 게시글 -> 댓글 리스트 조회")
+    @Test
+    public void articleComments() throws Exception {
+        // then
+        mvc.perform(get("/api/articles/1/articleComments"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+
+    @DisplayName("[api] 댓글 리스트")
+    @Test
+    public void allArticleComments() throws Exception {
+        // then
+        mvc.perform(get("/api/articleComments"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+
+    @DisplayName("[api] 댓글 단건 조회")
+    @Test
+    public void oneArticleComments() throws Exception {
+        // then
+        mvc.perform(get("/api/articleComments/1"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+}

--- a/src/test/java/com/projectboard/repository/JpaRepositoryTest.java
+++ b/src/test/java/com/projectboard/repository/JpaRepositoryTest.java
@@ -1,7 +1,7 @@
-package com.projectboard.projectboard.repository;
+package com.projectboard.repository;
 
-import com.projectboard.projectboard.config.JpaConfig;
-import com.projectboard.projectboard.domain.Article;
+import com.projectboard.config.JpaConfig;
+import com.projectboard.domain.Article;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import org.junit.jupiter.api.DisplayName;


### PR DESCRIPTION
게시글, 댓글 데이터는 간편하게 Spring Data REST로 서비스하고 해당 API에 대해 존재 여부만 확인하는 통합 테스트 작성